### PR TITLE
Table(Base): codecs should be taken at construction, not at method call site

### DIFF
--- a/core/src/grist/DocumentBase.scala
+++ b/core/src/grist/DocumentBase.scala
@@ -1,17 +1,17 @@
 package grist
 
-import io.circe.{Decoder, Encoder, Json}
+import io.circe.Json
 import zio.Task
 
 trait DocumentBase {
   trait TableBase[A] {
-    def getRecords(filter: Map[String, Set[Json]] = Map.empty)(implicit decoder: Decoder[A]): Task[List[Record[A]]]
+    def getRecords(filter: Map[String, Set[Json]] = Map.empty): Task[List[Record[A]]]
 
-    def getRecordsById(ids: Set[Reference[A]])(implicit decoder: Decoder[A]): Task[List[Record[A]]]
+    def getRecordsById(ids: Set[Reference[A]]): Task[List[Record[A]]]
 
-    def getRecordById(id: Reference[A])(implicit decoder: Decoder[A]): Task[A]
+    def getRecordById(id: Reference[A]): Task[A]
 
-    def addRecords(records: Seq[A])(implicit encoder: Encoder.AsObject[A]): Task[List[Reference[A]]]
+    def addRecords(records: Seq[A]): Task[List[Reference[A]]]
 
     def addRecordRaw(record: Map[String, Json]): Task[Int]
 


### PR DESCRIPTION
This ensures data consistency, and keeps false IDE errors from showing up in the business logic

Also, use Encoder instead of Encoder.AsObject, since IntelliJ doesn't seem to understand that @JsonCodec generates the latter
